### PR TITLE
Update istorex

### DIFF
--- a/luci/luci-app-istorex/root/etc/config/istorex
+++ b/luci/luci-app-istorex/root/etc/config/istorex
@@ -1,3 +1,3 @@
 config istorex
-	option 'enabled' '1'
-	option 'model'  'wizard'
+	option enabled '1'
+	option model  'wizard'


### PR DESCRIPTION
配置文件中的enabled与model 不能加‘’符号，否则导致向导模式出错。